### PR TITLE
Update the standalone version command to work with ncWMS2-standalone.jar

### DIFF
--- a/ncWMS_user_guide.md
+++ b/ncWMS_user_guide.md
@@ -19,7 +19,7 @@ Installation
 
 ### Standalone version
 
-The standalone version of ncWMS requires no installation.  It can be run from the command-line with the command `java -jar ncWMS-standalone.jar`.  This will run the WMS server locally with no security for administration and configuration.  It will be available at http://localhost:8080/.  All configuration etc. is identical to the standard version.
+The standalone version of ncWMS requires no installation.  It can be run from the command-line with the command `java -jar ncWMS2-standalone.jar`.  This will run the WMS server locally with no security for administration and configuration.  It will be available at http://localhost:8080/.  All configuration etc. is identical to the standard version.
 
 ### Installation
 


### PR DESCRIPTION
Following the user guide I had to use a slightly different command to get the ncWMS2 standalone to work. 