### PR TITLE
add check for GetLegendGraphic parameters 'layer' and 'style'

### DIFF
--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/GetMapStyleParams.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/GetMapStyleParams.java
@@ -135,6 +135,18 @@ public class GetMapStyleParams {
         }
 
         if (xmlStyle == null) {
+            /*
+             * Check if this a request with LAYER parameter required for GetLegendGraphic
+             */
+            String layerStr = params.getString("layer");
+            if (layerStr != null && layersStr == null) {
+                layers = new String[]{layerStr};
+            }
+            String styleStr = params.getString("style");
+            if (stylesStr != null && stylesStr == null) {
+                styles = new String[]{styleStr};
+            }
+
             if (layers == null) {
                 throw new EdalException(
                         "You must specify either SLD, SLD_BODY or LAYERS and STYLES");

--- a/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsServlet.java
+++ b/wms/src/main/java/uk/ac/rdg/resc/edal/wms/WmsServlet.java
@@ -2009,7 +2009,7 @@ public class WmsServlet extends HttpServlet {
                         "Requested layer is either not present, disabled, or not yet loaded.");
             } catch (Exception e) {
                 throw new MetadataException(
-                        "You must specify either SLD, SLD_BODY or LAYERS and STYLES for a full legend.  You may set COLORBARONLY=true to just generate a colour bar");
+                        "You must specify either SLD, SLD_BODY, LAYERS and STYLES, or LAYER and STYLE for a full legend.  You may set COLORBARONLY=true to just generate a colour bar");
             }
             /*
              * Test whether we have categorical data - this will generate a


### PR DESCRIPTION
The spec for SLD indicates that GetLegendGraphic has the required parameters of 'layer' and 'style' (see http://www.opengeospatial.org/standards/sld).  I've add a check in GetMapStyleParams for these params, but I'm not convinced it's at the right level of abstraction.

Thoughts?