### PR TITLE
Update URL for NASA Blue Marble WMS.

### DIFF
--- a/godiva/src/main/java/uk/ac/rdg/resc/godiva/client/widgets/MapArea.java
+++ b/godiva/src/main/java/uk/ac/rdg/resc/godiva/client/widgets/MapArea.java
@@ -1098,7 +1098,7 @@ public class MapArea extends MapWidget implements OpacitySelectionHandler, Centr
         wmsParams.setFormat("image/png");
         wmsParams.setParameter("version", "1.3.0");
 
-        String nasaMapServerUrl = "http://neowms.sci.gsfc.nasa.gov/wms/wms?";
+        String nasaMapServerUrl = "https://neo.gsfc.nasa.gov/wms/wms?";
         nasaBlueMarble = new WMS("NASA Blue Marble WMS", nasaMapServerUrl, wmsParams, wmsOptions);
         nasaBlueMarble.addLayerLoadStartListener(loadStartListener);
         nasaBlueMarble.addLayerLoadEndListener(loadEndListener);


### PR DESCRIPTION
While working on #142 for our THREDDS release, I noticed that the NASA Blue Marble base layer was failing. Found [this NASA blog post](https://neo.gsfc.nasa.gov/blog/2021/02/08/how-to-add-neo-layers-to-your-map-using-the-neo-web-mapping-service/) on the NEO WMS service which gives the new URL.