### PR TITLE
Improve error message

### DIFF
--- a/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmDatasetFactory.java
+++ b/cdm/src/main/java/uk/ac/rdg/resc/edal/dataset/cdm/CdmDatasetFactory.java
@@ -130,7 +130,7 @@ public abstract class CdmDatasetFactory extends DatasetFactory {
              */
             return dataset;
         } catch (Throwable e) {
-            throw new EdalException("Problem creating dataset " + id + " at " + location, e);
+            throw new EdalException("Problem creating dataset " + id, e);
         } finally {
             NetcdfDatasetAggregator.releaseDataset(nc);
         }


### PR DESCRIPTION
We noticed in TDS that this error message can contain absolute file paths. This change would leave out the file location.