### PR TITLE
Upgrade the Unidata library

### DIFF
--- a/cdm/pom.xml
+++ b/cdm/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>..</relativePath>
     </parent>
     <properties>
-        <netcdfversion>5.3.2</netcdfversion>
+        <netcdfversion>5.5.3</netcdfversion>
     </properties>
     <artifactId>edal-cdm</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
Hi

Simple PR for upgrading the Unidata libs to a newer version. I see similar work (and much more) is already done here: https://github.com/Reading-eScience-Centre/edal-java/compare/master...Unidata:edal-java:unidata_main.

I had to do some quick hack (not checked in) to get the h2 database to work locally on Windows and built a -SNAPSHOT version that I could test our service with. Maven built without errors and our server functioned without issue.

Reason for upgrade was Netcdf files and that has been refactored in the current version leaving only deprecated methods for creating netcdf files.

Thanks for a great library.